### PR TITLE
SK: fix: stop PosMintingBackgroundService on Serf exit

### DIFF
--- a/cypcore/Extensions/AppExtenstions.cs
+++ b/cypcore/Extensions/AppExtenstions.cs
@@ -302,13 +302,12 @@ namespace CYPCore.Extensions
                 var localNode = c.Resolve<ILocalNode>();
                 var signing = c.Resolve<ISigning>();
                 var lifetime = c.Resolve<IHostApplicationLifetime>();
-                var unitOfWork = c.Resolve<IUnitOfWork>();
                 var serfClient = c.Resolve<ISerfClient>();
                 var logger = c.Resolve<ILogger<SerfService>>();
 
                 var serfService = new SerfService(serfClient, signing, logger);
 
-                serfService.StartAsync(lifetime.ApplicationStopping).ConfigureAwait(false).GetAwaiter();
+                serfService.StartAsync(lifetime).ConfigureAwait(false).GetAwaiter();
 
                 ct.CancelAfter(30000);
 

--- a/cypcore/Services/ISerfService.cs
+++ b/cypcore/Services/ISerfService.cs
@@ -1,8 +1,8 @@
 ﻿// CYPCore by Matthew Hellyer is licensed under CC BY-NC-ND 4.0.
 // To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-nd/4.0
 
-using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 
 using CYPCore.Models;
 
@@ -10,7 +10,7 @@ namespace CYPCore.Services
 {
     public interface ISerfService
     {
-        Task StartAsync(CancellationToken stoppingToken);
+        Task StartAsync(IHostApplicationLifetime applicationLifetime);
         Task JoinSeedNodes(SeedNode seedNode);
     }
 }


### PR DESCRIPTION
When Serf exits gracefully by itself, the PosMintingBackgroundService keeps on running. This change will stop the minting service, so the application terminates.
To be checked: in case the PosMintingBackgroundService can be started when Serf throws an exception, this will also need to be fixed.