### PR TITLE
fix(build): fix implicit analyzer build warning

### DIFF
--- a/cypnode/cypnode.csproj
+++ b/cypnode/cypnode.csproj
@@ -37,6 +37,11 @@
     <DefineConstants>BUILD_WIN</DefineConstants>
   </PropertyGroup>
 
+  <!-- Not disabling these implicit analyzers causes a build warning -->
+  <PropertyGroup>
+    <DisableImplicitAspNetCoreAnalyzers>true</DisableImplicitAspNetCoreAnalyzers>
+  </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="StartupExtensions\" />
   </ItemGroup>


### PR DESCRIPTION
For mainnet we do not want to supply releases with build warnings. This fixes one of the remaining warnings in the project.