### PR TITLE
refactor: lower-case assembly name

### DIFF
--- a/cypnode/cypnode.csproj
+++ b/cypnode/cypnode.csproj
@@ -7,25 +7,25 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <AssemblyName>CYPNode</AssemblyName>
+    <AssemblyName>cypnode</AssemblyName>
     <RootNamespace>CYPNode</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <LangVersion>9.0</LangVersion>
-    <AssemblyName>CYPNode</AssemblyName>
+    <AssemblyName>cypnode</AssemblyName>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LangVersion>9.0</LangVersion>
-    <AssemblyName>CYPNode</AssemblyName>
+    <AssemblyName>cypnode</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <LangVersion>9.0</LangVersion>
-    <AssemblyName>CYPNode</AssemblyName>
+    <AssemblyName>cypnode</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LangVersion>9.0</LangVersion>
-    <AssemblyName>CYPNode</AssemblyName>
+    <AssemblyName>cypnode</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'CYPNode' " />
 


### PR DESCRIPTION
Binaries usually have lower-case names. This change will build 'cypnode' instead of 'CYPNode'.