### PR TITLE
feat(config): system-wide config fallback

### DIFF
--- a/cypcore/Helper/Util.cs
+++ b/cypcore/Helper/Util.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json.Linq;
 using ProtoBuf;
 
 using System.Net;
+using System.Runtime.CompilerServices;
 using CYPCore.Extentions;
 using System.Security.Cryptography;
 
@@ -418,5 +419,52 @@ namespace CYPCore.Helper
         {
             return new DateTimeOffset(GetAdjustedTime()).ToUnixTimeSeconds();
         }
+        
+        public static class OperatingSystem
+        {
+            public static bool IsLinux() =>
+                RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            
+            public static bool IsMacOS() =>
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            
+            public static bool IsWindows() =>
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        public static class ConfigurationFile
+        {
+            private const string AppSettingsFilename = "appsettings.json";
+
+            public static string Local() => Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                AppSettingsFilename);
+            
+            private static string SystemDefaultLinux() => Path.Combine("/etc", "tangram", "cypher", AppSettingsFilename);
+            private static string SystemDefaultMacOS() => throw new Exception("No macOS system default implemented yet");
+            private static string SystemDefaultWindows() => Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                AppSettingsFilename);
+            public static string SystemDefault()
+            {
+                if (OperatingSystem.IsLinux())
+                {
+                    return SystemDefaultLinux();
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    return SystemDefaultMacOS();
+                }
+                else if (OperatingSystem.IsWindows())
+                {
+                    return SystemDefaultWindows();
+                }
+                else
+                {
+                    throw new Exception("Unknown operating system");
+                }
+            }
+        }
+
     }
 }

--- a/cypcore/Helper/Util.cs
+++ b/cypcore/Helper/Util.cs
@@ -419,15 +419,15 @@ namespace CYPCore.Helper
         {
             return new DateTimeOffset(GetAdjustedTime()).ToUnixTimeSeconds();
         }
-        
+
         public static class OperatingSystem
         {
             public static bool IsLinux() =>
                 RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            
+
             public static bool IsMacOS() =>
                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-            
+
             public static bool IsWindows() =>
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
@@ -439,7 +439,7 @@ namespace CYPCore.Helper
             public static string Local() => Path.Combine(
                 Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
                 AppSettingsFilename);
-            
+
             private static string SystemDefaultLinux() => Path.Combine("/etc", "tangram", "cypher", AppSettingsFilename);
             private static string SystemDefaultMacOS() => throw new Exception("No macOS system default implemented yet");
             private static string SystemDefaultWindows() => Path.Combine(

--- a/cypnode/Program.cs
+++ b/cypnode/Program.cs
@@ -3,10 +3,14 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
 using Autofac.Extensions.DependencyInjection;
+using CYPCore.Helper;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 using Serilog.Events;
@@ -17,17 +21,6 @@ namespace CYPNode
 {
     public static class Program
     {
-        static IConfigurationRoot ConfigurationRoot
-        {
-            get
-            {
-                return new ConfigurationBuilder()
-                                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
-                                .AddJsonFile("appsettings.json")
-                                .Build();
-            }
-        }
-
         /// <summary>
         ///
         /// </summary>
@@ -35,7 +28,32 @@ namespace CYPNode
         /// <returns></returns>
         public static int Main(string[] args)
         {
-            if (ConfigurationRoot.GetValue<bool>("Log:FirstChanceException"))
+            var configFile = args.SkipWhile(arg => !arg.Equals("--config")).Skip(1).FirstOrDefault();
+            if (string.IsNullOrEmpty(configFile))
+            {
+                // No config file set, check in current path (priority over system default)
+                configFile = Util.ConfigurationFile.Local();
+
+                // If no config file in current path, use system default
+                if (!File.Exists(configFile))
+                {
+                    configFile = Util.ConfigurationFile.SystemDefault();
+                }
+            }
+            
+            IConfigurationRoot configurationRoot = null;
+            if (File.Exists(configFile))
+            {
+                configurationRoot = new ConfigurationBuilder()
+                    .AddJsonFile(configFile)
+                    .Build();
+            }
+            else
+            {
+                throw new FileNotFoundException($"Cannot find configuration file {@configFile}", configFile);
+            }
+
+            if (configurationRoot.GetValue<bool>("Log:FirstChanceException"))
             {
                 AppDomain.CurrentDomain.FirstChanceException += (sender, e) =>
                 {
@@ -44,13 +62,28 @@ namespace CYPNode
             }
 
             Log.Logger = new LoggerConfiguration()
-                .ReadFrom.Configuration(ConfigurationRoot, "Log")
+                .ReadFrom.Configuration(configurationRoot, "Log")
                 .CreateLogger();
 
+            Log.Information("Using application configuration from {@configFile}", configFile);
+            
             try
             {
                 Log.Information("Starting web host");
-                var builder = CreateWebHostBuilder(args);
+                var builder = CreateWebHostBuilder(args, configurationRoot);
+
+                if (Util.OperatingSystem.IsLinux())
+                {
+                    builder.UseSystemd();
+                }
+                else if (Util.OperatingSystem.IsMacOS())
+                {
+                    // TODO
+                }
+                else if (Util.OperatingSystem.IsWindows())
+                {
+                    builder.UseWindowsService();
+                }
 
                 using IHost host = builder.Build();
 
@@ -75,29 +108,17 @@ namespace CYPNode
             return 0;
         }
 
-        private static IHostBuilder CreateWebHostBuilder(string[] args) =>
+        private static IHostBuilder CreateWebHostBuilder(string[] args, IConfigurationRoot configurationRoot) =>
             Host.CreateDefaultBuilder(args)
                 .UseServiceProviderFactory(new AutofacServiceProviderFactory())
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     ApiConfigurationOptions apiConfigurationOptions = new();
-                    ConfigurationRoot.Bind("Api", apiConfigurationOptions);
+                    configurationRoot.Bind("Api", apiConfigurationOptions);
 
                     webBuilder.UseStartup<Startup>()
                         .UseUrls(apiConfigurationOptions.Listening)
                         .UseSerilog();
-                })
-
-                // Use .NET Core system daemon support when applicable. This define can be set by setting the runtime
-                // identifier (dotnet --runtime) to "linux_x64", "win-x64", etc. See cypnode.csproj for details.
-#if BUILD_LINUX
-                .UseSystemd();
-#elif BUILD_MACOS
-                ; // TODO: Check macOS support
-#elif BUILD_WIN
-                .UseWindowsService();
-#else
-                ;
-#endif
+                });
     }
 }

--- a/cypnode/Program.cs
+++ b/cypnode/Program.cs
@@ -40,7 +40,7 @@ namespace CYPNode
                     configFile = Util.ConfigurationFile.SystemDefault();
                 }
             }
-            
+
             IConfigurationRoot configurationRoot = null;
             if (File.Exists(configFile))
             {
@@ -66,7 +66,7 @@ namespace CYPNode
                 .CreateLogger();
 
             Log.Information("Using application configuration from {@configFile}", configFile);
-            
+
             try
             {
                 Log.Information("Starting web host");

--- a/cypnode/cypnode.csproj
+++ b/cypnode/cypnode.csproj
@@ -29,14 +29,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'CYPNode' " />
 
-  <!-- Build-time defines to enable certain platform-specific parts of code dependent on the target platform -->
-  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(RuntimeIdentifier)', '^linux-'))">
-    <DefineConstants>BUILD_LINUX</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(RuntimeIdentifier)', '^win-'))">
-    <DefineConstants>BUILD_WIN</DefineConstants>
-  </PropertyGroup>
-
   <!-- Not disabling these implicit analyzers causes a build warning -->
   <PropertyGroup>
     <DisableImplicitAspNetCoreAnalyzers>true</DisableImplicitAspNetCoreAnalyzers>


### PR DESCRIPTION
This change takes the config file as command-line parameter or reads appsettings.json from the same path as cypnode is located. As a fallback for the latter case, a system-wide configuration setting is used dependent on the running platform.