### PR TITLE
sk: feat(test): add node monitor service

### DIFF
--- a/cypcore/Extensions/AppExtensions.cs
+++ b/cypcore/Extensions/AppExtensions.cs
@@ -21,6 +21,7 @@ using CYPCore.Serf;
 using CYPCore.Persistence;
 using CYPCore.Network;
 using CYPCore.Cryptography;
+using CYPCore.Helper;
 using CYPCore.Ledger;
 
 namespace CYPCore.Extensions
@@ -136,7 +137,7 @@ namespace CYPCore.Extensions
                 (
                      c.Resolve<ISerfClient>(),
                      c.Resolve<Serilog.ILogger>()
-                 );
+                );
 
                 return localNode;
             })
@@ -311,5 +312,28 @@ namespace CYPCore.Extensions
             builder.RegisterType<BlockService>().As<IBlockService>();
             return builder;
         }
+
+        public static ContainerBuilder AddNodeMonitorService(this ContainerBuilder builder, IConfiguration configuration)
+        {
+            builder.Register(c =>
+                {
+                    var nodeMonitorConfigurationOptions = new NodeMonitorConfigurationOptions();
+                    configuration.Bind(NodeMonitorConfigurationOptions.ConfigurationSectionName, nodeMonitorConfigurationOptions);
+
+                    var nodeMonitorProvider =
+                        new NodeMonitor(
+                            nodeMonitorConfigurationOptions,
+                            c.Resolve<Serilog.ILogger>());
+
+                    return nodeMonitorProvider;
+                })
+                .As<INodeMonitor>()
+                .InstancePerLifetimeScope();
+
+            builder.RegisterType<NodeMonitorService>().As<IHostedService>().SingleInstance();
+
+            return builder;
+        }
+
     }
 }

--- a/cypcore/Helper/NodeMonitor.cs
+++ b/cypcore/Helper/NodeMonitor.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using Serilog;
+
+using CYPCore.Extensions;
+using CYPCore.Models;
+
+namespace CYPCore.Helper
+{
+    public interface INodeMonitor
+    {
+        public bool Start();
+        public void Stop();
+        public void Listen(CancellationToken cancellationToken);
+    }
+
+    public class NodeMonitor : INodeMonitor
+    {
+        private readonly ILogger _logger;
+        private readonly NodeMonitorConfigurationOptions _configuration;
+        private readonly TcpListener _listener;
+
+        public NodeMonitor(NodeMonitorConfigurationOptions configuration, ILogger logger)
+        {
+            _logger = logger.ForContext("SourceContext", nameof(NodeMonitor));
+            _configuration = configuration;
+
+            if (_configuration.Enabled)
+            {
+                try
+                {
+                    var ipAddress = IPAddress.Parse(_configuration.Listening);
+                    var endPoint = new IPEndPoint(ipAddress, _configuration.Port);
+                    _listener = new TcpListener(endPoint);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Here().Error(ex, "Cannot initialize node monitor service");
+                }
+            }
+        }
+
+        public bool Start()
+        {
+            try
+            {
+                _listener.Start();
+            }
+            catch (Exception ex)
+            {
+                _logger.Here().Error(ex, "Cannot start TCP listener");
+                return false;
+            }
+
+            return true;
+        }
+
+        public void Stop()
+        {
+            if (_configuration.Enabled)
+            {
+                try
+                {
+                    _listener.Stop();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Here().Error(ex, "Error while stopping TCP listener");
+                }
+            }
+        }
+
+        public async void Listen(CancellationToken cancellationToken)
+        {
+            var buffer = new byte[_listener.Server.ReceiveBufferSize];
+
+            try
+            {
+                var client = await AcceptAsync(cancellationToken);
+                _logger.Here().Information("Client connected");
+
+                while (client.Connected)
+                {
+                    var bytesReceived = await client.GetStream().ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+                    if (bytesReceived == 0)
+                    {
+                        _logger.Here().Debug("Received 0 bytes, connection terminated");
+                        break;
+                    }
+
+                    _logger.Here().Debug("Received {@NumBytes} bytes", bytesReceived);
+                }
+                _logger.Here().Information("Client disconnected");
+
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.Here().Debug("Listener interrupted");
+            }
+        }
+
+        private async Task<TcpClient> AcceptAsync(CancellationToken cancellationToken)
+        {
+            await using (cancellationToken.Register(_listener.Stop))
+            {
+                try
+                {
+                    return await _listener.AcceptTcpClientAsync();
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.Interrupted)
+                {
+                    _logger.Here().Information("Operation cancelled");
+                    throw new OperationCanceledException();
+                }
+                catch (ObjectDisposedException ex) when (cancellationToken.IsCancellationRequested)
+                {
+                    _logger.Here().Information("Operation cancelled");
+                    throw new OperationCanceledException();
+                }
+            }
+        }
+    }
+}

--- a/cypcore/Models/NodeMonitorConfigurationOptions.cs
+++ b/cypcore/Models/NodeMonitorConfigurationOptions.cs
@@ -1,0 +1,13 @@
+using System.Net;
+
+namespace CYPCore.Models
+{
+    public class NodeMonitorConfigurationOptions
+    {
+        public static string ConfigurationSectionName = "NodeMonitor";
+
+        public bool Enabled { get; set; }
+        public string Listening { get; set; }
+        public ushort Port { get; set; }
+    }
+}

--- a/cypcore/Services/NodeMonitorService.cs
+++ b/cypcore/Services/NodeMonitorService.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+using Serilog;
+
+using CYPCore.Extensions;
+using CYPCore.Helper;
+
+namespace CYPCore.Services
+{
+    public class NodeMonitorService : BackgroundService
+    {
+        private ILogger _logger;
+        private readonly INodeMonitor _nodeMonitor;
+
+        //        private readonly NodeMonitorConfigurationOptions _configuration;
+        private bool _applicationRunning = true;
+        private readonly ushort _taskDelay = 10000;
+
+        public NodeMonitorService(INodeMonitor nodeMonitor, IHostApplicationLifetime applicationLifetime, ILogger logger)
+        {
+            _logger = logger.ForContext("SourceContext", nameof(NodeMonitorService));
+            _nodeMonitor = nodeMonitor;
+
+            applicationLifetime.ApplicationStopping.Register(OnApplicationStopping);
+        }
+
+        private void OnApplicationStopping()
+        {
+            _logger.Here().Information("Application stopping");
+            _nodeMonitor.Stop();
+            _applicationRunning = false;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var nodeMonitorStarted = _nodeMonitor.Start();
+                _logger.Here().Debug("Node monitor started: {@NodeMonitorStarted}", nodeMonitorStarted);
+                if (!nodeMonitorStarted)
+                {
+                    return;
+                }
+
+                while (_applicationRunning)
+                {
+                    _nodeMonitor.Listen(cancellationToken);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+
+            }
+            catch (Exception ex)
+            {
+                _logger.Here().Error(ex, "Error in node monitor process");
+            }
+        }
+    }
+}

--- a/cypnode/Startup.cs
+++ b/cypnode/Startup.cs
@@ -56,6 +56,7 @@ namespace CYPNode
         public void ConfigureContainer(ContainerBuilder builder)
         {
             builder.AddSerilog();
+            builder.AddNodeMonitorService(Configuration);
             builder.AddSwimGossipClient(Configuration);
             builder.AddSerfProcessService(Configuration);
             builder.AddUnitOfWork(Configuration);

--- a/cypnode/appsettings.json
+++ b/cypnode/appsettings.json
@@ -32,6 +32,11 @@
       }
     ]
   },
+  "NodeMonitor": {
+    "Enabled": false,
+    "Listening": "127.0.0.1",
+    "Port": 7005
+  },
   "SeedNodes": [ "67.205.161.184:7946" ],
   "Serf": {
     "Advertise": "",


### PR DESCRIPTION
The node monitor service will provide an event logger over a TCP socket, so that automated testers like Robot Framework can interact with and monitor the node during testing.