### PR TITLE
feat(log): add seq sink

### DIFF
--- a/cypcore/cypcore.csproj
+++ b/cypcore/cypcore.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0-dev-00909" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.0.0" />
     <PackageReference Include="Stratis.Patricia" Version="1.0.7" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
     <PackageReference Include="RocksDbNative" Version="6.2.2" />

--- a/cypnode/Program.cs
+++ b/cypnode/Program.cs
@@ -23,9 +23,10 @@ namespace CYPNode
         /// <returns></returns>
         public static int Main(string[] args)
         {
+            var settingsFile = $"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json";
             var config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", optional: false)
+                .AddJsonFile(settingsFile, optional: false)
                 .AddCommandLine(args)
                 .Build();
 

--- a/cypnode/appsettings.Production.json
+++ b/cypnode/appsettings.Production.json
@@ -8,7 +8,7 @@
   "Log": {
     "FirstChanceException": false,
     "MinimumLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Information"
       }
@@ -31,13 +31,6 @@
         }
       }
     ]
-  },
-  "NodeMonitor": {
-    "Enabled": false,
-    "Tester": {
-      "Listening": "127.0.0.1",
-      "Port": 7005
-    }
   },
   "SeedNodes": [ "67.205.161.184:7946" ],
   "Serf": {


### PR DESCRIPTION
The Seq sink allows for easier log analysis. The sink is only configured in development mode and does not block when Seq is not installed.

See https://hub.docker.com/r/datalust/seq for Seq installation instructions.