### PR TITLE
fix(46): check for 'pubkey' entry in tag dictionary before usage

### DIFF
--- a/cypcore/Network/LocalNode.cs
+++ b/cypcore/Network/LocalNode.cs
@@ -130,7 +130,11 @@ namespace CYPCore.Network
 
             var membersResult = await _serfClient.Members(tcpSession.SessionId);
             var members = membersResult.Value.Members.ToList();
-            foreach (var member in members.Where(member => _serfClient.Name != member.Name && member.Status == "alive" && member.Tags.Count != 0))
+            foreach (var member in members.Where(member =>
+                _serfClient.Name != member.Name &&
+                member.Status == "alive" &&
+                member.Tags.ContainsKey("pubkey") &&
+                member.Tags.ContainsKey("rest")))
             {
                 try
                 {


### PR DESCRIPTION
This is most likely due to Serf agents missing the "pubkey" key in the tags dictionary and not checking for the existence of this key before getting the value in https://github.com/cypher-network/cypher/blob/9fcf1bafb3868628a1193cdbf3ffcd8c0814cd57/cypcore/Network/LocalNode.cs#L137

This fix checks whether the keys are available before reading them.