### PR TITLE
refactor: stoppable blockmania listener

### DIFF
--- a/cypcore/Ledger/BlockGraphCollector.cs
+++ b/cypcore/Ledger/BlockGraphCollector.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CYPCore.Consensus.Models;
+using CYPCore.Extensions;
+using Dawn;
+using Serilog;
+
+namespace CYPCore.Ledger
+{
+    public class BlockGraphCollector
+    {
+        private readonly ILogger _logger;
+        private readonly Dictionary<ulong, BlockGraphCollectorTimedRound> _rounds = new();
+        private const int PurgeAfterRounds = 5;
+
+        public BlockGraphCollector(Action<HashSet<BlockGraph>, ulong, Action<bool>> processFunc, ILogger logger)
+        {
+            Guard.Argument(processFunc, nameof(processFunc)).NotNull();
+            Guard.Argument(logger, nameof(logger)).NotNull();
+
+            _logger = logger.ForContext("SourceContext", nameof(BlockGraphCollector));
+            CollectorConfig.ProcessFunc = processFunc;
+        }
+
+        public BlockGraphCollectorTimedRound.CollectorConfig CollectorConfig { get; set; } = new();
+
+        public void Add(BlockGraph blockGraph)
+        {
+            Guard.Argument(blockGraph, nameof(blockGraph)).NotNull();
+
+            if (!_rounds.ContainsKey(blockGraph.Block.Round))
+            {
+                _logger.Here().Debug("First block for round {@Round}, creating timed collection", blockGraph.Block.Round);
+                _rounds.Add(blockGraph.Block.Round, new BlockGraphCollectorTimedRound(
+                    CollectorConfig, blockGraph.Block.Round, _logger));
+
+                PurgeRounds(blockGraph.Block.Round);
+            }
+
+            if (_rounds.TryGetValue(blockGraph.Block.Round, out var round))
+            {
+                round.Add(blockGraph);
+            }
+            else
+            {
+                _logger.Here().Fatal("Cannot get blockgraphs for round {@Round}", round);
+            }
+        }
+
+        private void PurgeRounds(ulong currentRound)
+        {
+            _rounds
+                .Where(round =>
+                    round.Key + PurgeAfterRounds < currentRound &&
+                    round.Value.RoundFinished)
+                .ForEach(round =>
+                {
+                    _rounds.Remove(round.Key);
+                });
+        }
+    }
+}

--- a/cypcore/Ledger/BlockGraphCollectorTimedRound.cs
+++ b/cypcore/Ledger/BlockGraphCollectorTimedRound.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Timers;
+using CYPCore.Consensus.Models;
+using CYPCore.Extensions;
+using Serilog;
+
+namespace CYPCore.Ledger
+{
+    public class BlockGraphCollectorTimedRound
+    {
+        private readonly ILogger _logger;
+        private readonly HashSet<BlockGraph> _blocks;
+        private readonly ulong _round;
+        private readonly CollectorConfig _config;
+        private System.Timers.Timer _timeout;
+
+        private readonly object _roundClosedGuard = new();
+        private bool _roundClosed = false;
+
+        public bool RoundFinished
+        {
+            get;
+            private set;
+        } = false;
+
+        public class CollectorConfig
+        {
+            public Action<HashSet<BlockGraph>, ulong, Action<bool>> ProcessFunc;
+            public bool ProcessInNewThread = true;
+            public int MaxBlocksPerRound = 500;
+            public TimeSpan GraceTime = TimeSpan.FromSeconds(10);
+        }
+
+        public BlockGraphCollectorTimedRound(
+            CollectorConfig config,
+            ulong round,
+            ILogger logger)
+        {
+            _logger = logger.ForContext("SourceContext", $"{nameof(BlockGraphCollectorTimedRound)}:{round}");
+            _round = round;
+            _config = config;
+            _blocks = new HashSet<BlockGraph>(config.MaxBlocksPerRound);
+
+            _timeout = new Timer(_config.GraceTime.TotalMilliseconds);
+            _timeout.AutoReset = false;
+            _timeout.Elapsed += OnTimeout;
+            _timeout.Enabled = true;
+
+            ResetTimer();
+        }
+
+        private void ResetTimer()
+        {
+            _timeout.Stop();
+            _timeout.Start();
+        }
+
+        public void Add(BlockGraph blockGraph)
+        {
+            lock (_roundClosedGuard)
+            {
+                if (!_roundClosed)
+                {
+                    if (_blocks.Add(blockGraph))
+                    {
+                        if (_blocks.Count == _config.MaxBlocksPerRound)
+                        {
+                            StartProcess();
+                        }
+                        else
+                        {
+                            ResetTimer();
+                        }
+                    }
+                    else
+                    {
+                        _logger.Here().Error("Cannot add blockgraph from {@Node}. Possible duplicate?",
+                            blockGraph.Block.Node);
+                    }
+
+                }
+                else
+                {
+                    _logger.Here().Debug("{@Node} tried to add block to closed round {@Round}",
+                        blockGraph.Block.Node,
+                        blockGraph.Block.Round);
+                }
+            }
+        }
+
+        private void OnTimeout(object _1, ElapsedEventArgs _2)
+        {
+            lock (_roundClosedGuard)
+            {
+                StartProcess();
+            }
+        }
+
+        private void StartProcess()
+        {
+            _timeout.Enabled = false;
+            _roundClosed = true;
+
+            if (_config.ProcessInNewThread)
+            {
+                Task.Run(() => _config.ProcessFunc(_blocks, _round, finished => RoundFinished = finished));
+            }
+            else
+            {
+                _config.ProcessFunc(_blocks, _round, finished => RoundFinished = finished);
+            }
+        }
+    }
+}

--- a/cypcore/Ledger/BlockGraphCollectorTimedRound.cs
+++ b/cypcore/Ledger/BlockGraphCollectorTimedRound.cs
@@ -92,7 +92,10 @@ namespace CYPCore.Ledger
         {
             lock (_roundClosedGuard)
             {
-                StartProcess();
+                if (!_roundClosed)
+                {
+                    StartProcess();
+                }
             }
         }
 

--- a/cypcore/Ledger/BlockGraphCollectorTimedRound.cs
+++ b/cypcore/Ledger/BlockGraphCollectorTimedRound.cs
@@ -14,7 +14,7 @@ namespace CYPCore.Ledger
         private readonly HashSet<BlockGraph> _blocks;
         private readonly ulong _round;
         private readonly CollectorConfig _config;
-        private System.Timers.Timer _timeout;
+        private Timer _timeout;
 
         private readonly object _roundClosedGuard = new();
         private bool _roundClosed = false;
@@ -47,8 +47,6 @@ namespace CYPCore.Ledger
             _timeout.AutoReset = false;
             _timeout.Elapsed += OnTimeout;
             _timeout.Enabled = true;
-
-            ResetTimer();
         }
 
         private void ResetTimer()

--- a/cypcore/Ledger/PosMinting.cs
+++ b/cypcore/Ledger/PosMinting.cs
@@ -128,8 +128,8 @@ namespace CYPCore.Ledger
                         if (x == null) return;
                         var hasAnyErrors = x.Validate();
                         if (hasAnyErrors.Any()) return;
-                            // ReSharper disable once AccessToDisposedClosure
-                            ts.Append(x.ToStream());
+                        // ReSharper disable once AccessToDisposedClosure
+                        ts.Append(x.ToStream());
                     }
                     catch (Exception)
                     {

--- a/test/unit/cypcore-test-unit/Ledger/BlockGraphCollectorTests.cs
+++ b/test/unit/cypcore-test-unit/Ledger/BlockGraphCollectorTests.cs
@@ -41,6 +41,8 @@ namespace cypcore_test_unit.Ledger
             }
         };
 
+        private BlockGraphCollectorTimedRound.CollectorConfig _config;
+
         [SetUp]
         public void Setup()
         {
@@ -49,9 +51,19 @@ namespace cypcore_test_unit.Ledger
                 .Setup(logger => logger.ForContext(It.IsAny<string>(), It.IsAny<string>(), false))
                 .Returns(_logger.Object);
 
+            _config = new()
+            {
+                GraceTime = TimeSpan.FromDays(1),
+                MaxBlocksPerRound = 1,
+                ProcessFunc = ProcessRound,
+                ProcessInNewThread = false,
+            };
+
             _blockGraphCollector = new BlockGraphCollector(
                 ProcessRound,
                 _logger.Object);
+
+            _blockGraphCollector.CollectorConfig = _config;
         }
 
         private struct ProcessResult
@@ -88,14 +100,6 @@ namespace cypcore_test_unit.Ledger
         {
             _processResults.Clear();
 
-            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
-            {
-                GraceTime = TimeSpan.FromDays(1),
-                MaxBlocksPerRound = 1,
-                ProcessFunc = ProcessRound,
-                ProcessInNewThread = false,
-            };
-
             _blockGraphCollector.Add(blockGraph_3_5);
 
             Assert.AreEqual(1, _processResults.Count);
@@ -105,14 +109,6 @@ namespace cypcore_test_unit.Ledger
         public void Collector_ProcessedRound_DoesNotProcessAdditionalBlockGraphs()
         {
             _processResults.Clear();
-
-            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
-            {
-                GraceTime = TimeSpan.FromDays(1),
-                MaxBlocksPerRound = 1,
-                ProcessFunc = ProcessRound,
-                ProcessInNewThread = false,
-            };
 
             _blockGraphCollector.Add(blockGraph_4_6);
             Assert.AreEqual(1, _processResults.Count);
@@ -126,13 +122,8 @@ namespace cypcore_test_unit.Ledger
         {
             _processResults.Clear();
 
-            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
-            {
-                GraceTime = TimeSpan.FromDays(1),
-                MaxBlocksPerRound = 2,
-                ProcessFunc = ProcessRound,
-                ProcessInNewThread = false,
-            };
+            _config.MaxBlocksPerRound = 2;
+            _blockGraphCollector.CollectorConfig = _config;
 
             _blockGraphCollector.Add(blockGraph_3_5);
             Assert.AreEqual(0, _processResults.Count);
@@ -152,13 +143,9 @@ namespace cypcore_test_unit.Ledger
         {
             _processResults.Clear();
 
-            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
-            {
-                GraceTime = TimeSpan.FromSeconds(3),
-                MaxBlocksPerRound = 10,
-                ProcessFunc = ProcessRound,
-                ProcessInNewThread = false,
-            };
+            _config.GraceTime = TimeSpan.FromSeconds(3);
+            _config.MaxBlocksPerRound = 10;
+            _blockGraphCollector.CollectorConfig = _config;
 
             _blockGraphCollector.Add(blockGraph_4_6);
             _blockGraphCollector.Add(blockGraph_5_6);

--- a/test/unit/cypcore-test-unit/Ledger/BlockGraphCollectorTests.cs
+++ b/test/unit/cypcore-test-unit/Ledger/BlockGraphCollectorTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CYPCore.Consensus.Models;
+using CYPCore.Ledger;
+using Moq;
+using NUnit.Framework;
+using Serilog;
+
+namespace cypcore_test_unit.Ledger
+{
+    public class BlockGraphCollectorTests
+    {
+        private Mock<ILogger> _logger;
+        private BlockGraphCollector _blockGraphCollector;
+
+        private BlockGraph blockGraph_3_5 = new()
+        {
+            Block = new Block
+            {
+                Node = 3,
+                Round = 5
+            }
+        };
+
+        private BlockGraph blockGraph_4_6 = new()
+        {
+            Block = new Block
+            {
+                Node = 4,
+                Round = 6
+            }
+        };
+
+        private BlockGraph blockGraph_5_6 = new()
+        {
+            Block = new Block
+            {
+                Node = 5,
+                Round = 6
+            }
+        };
+
+        [SetUp]
+        public void Setup()
+        {
+            _logger = new Mock<ILogger>();
+            _logger
+                .Setup(logger => logger.ForContext(It.IsAny<string>(), It.IsAny<string>(), false))
+                .Returns(_logger.Object);
+
+            _blockGraphCollector = new BlockGraphCollector(
+                ProcessRound,
+                _logger.Object);
+        }
+
+        private struct ProcessResult
+        {
+            public ulong Round;
+            public HashSet<BlockGraph> Blocks;
+        }
+
+        private List<ProcessResult> _processResults = new();
+        private void ProcessRound(HashSet<BlockGraph> blocks, ulong round, Action<bool> finishedCallback)
+        {
+            _processResults.Add(new ProcessResult
+            {
+                Round = round,
+                Blocks = blocks
+            });
+        }
+
+        [Test]
+        public void Instantiate_InvalidParams_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BlockGraphCollector(null, _logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new BlockGraphCollector(ProcessRound, null));
+        }
+
+        [Test]
+        public void Add_InvalidParam_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _blockGraphCollector.Add(null));
+        }
+
+        [Test]
+        public void Collector_MaxBlockGraphs_StartsProcessing()
+        {
+            _processResults.Clear();
+
+            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
+            {
+                GraceTime = TimeSpan.FromDays(1),
+                MaxBlocksPerRound = 1,
+                ProcessFunc = ProcessRound,
+                ProcessInNewThread = false,
+            };
+
+            _blockGraphCollector.Add(blockGraph_3_5);
+
+            Assert.AreEqual(1, _processResults.Count);
+        }
+
+        [Test]
+        public void Collector_ProcessedRound_DoesNotProcessAdditionalBlockGraphs()
+        {
+            _processResults.Clear();
+
+            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
+            {
+                GraceTime = TimeSpan.FromDays(1),
+                MaxBlocksPerRound = 1,
+                ProcessFunc = ProcessRound,
+                ProcessInNewThread = false,
+            };
+
+            _blockGraphCollector.Add(blockGraph_4_6);
+            Assert.AreEqual(1, _processResults.Count);
+
+            _blockGraphCollector.Add(blockGraph_5_6);
+            Assert.AreEqual(1, _processResults.Count);
+        }
+
+        [Test]
+        public void Collector_AddDifferentRound_DoesNotProcess()
+        {
+            _processResults.Clear();
+
+            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
+            {
+                GraceTime = TimeSpan.FromDays(1),
+                MaxBlocksPerRound = 2,
+                ProcessFunc = ProcessRound,
+                ProcessInNewThread = false,
+            };
+
+            _blockGraphCollector.Add(blockGraph_3_5);
+            Assert.AreEqual(0, _processResults.Count);
+
+            _blockGraphCollector.Add(blockGraph_4_6);
+            Assert.AreEqual(0, _processResults.Count);
+
+            _blockGraphCollector.Add(blockGraph_5_6);
+            Assert.AreEqual(1, _processResults.Count);
+
+            Assert.AreEqual(6, _processResults.First().Round);
+            Assert.AreEqual(2, _processResults.First().Blocks.Count);
+        }
+
+        [Test]
+        public void Collector_Timeout_StartsProcessing()
+        {
+            _processResults.Clear();
+
+            _blockGraphCollector.CollectorConfig = new BlockGraphCollectorTimedRound.CollectorConfig
+            {
+                GraceTime = TimeSpan.FromSeconds(3),
+                MaxBlocksPerRound = 10,
+                ProcessFunc = ProcessRound,
+                ProcessInNewThread = false,
+            };
+
+            _blockGraphCollector.Add(blockGraph_4_6);
+            _blockGraphCollector.Add(blockGraph_5_6);
+
+            Assert.AreEqual(0, _processResults.Count);
+
+            Assert.That(() => _processResults, Has.Count.EqualTo(1)
+                .After((_blockGraphCollector.CollectorConfig.GraceTime * 3).Seconds).Seconds
+                .PollEvery(250).MilliSeconds);
+
+            Assert.AreEqual(2, _processResults.First().Blocks.Count);
+        }
+    }
+}

--- a/test/unit/cypcore-test-unit/cypcore-test-unit.csproj
+++ b/test/unit/cypcore-test-unit/cypcore-test-unit.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />


### PR DESCRIPTION
The rx.net blockmania listener has been removed. The biggest drawback is lack of control to stop listening (and potentially processing) for specific blocks after a round has been processed.

The new implementation includes tests to validate whether the implemented behavior is as intended.