### PR TITLE
Reimplement message pipeline

### DIFF
--- a/cypcore/Ledger/Graph.cs
+++ b/cypcore/Ledger/Graph.cs
@@ -436,8 +436,7 @@ namespace CYPCore.Ledger
                 foreach (var next in blocks)
                 {
                     var blockGraph = await _unitOfWork.BlockGraphRepository.GetAsync(x =>
-                        new ValueTask<bool>(x.Block.Hash.Equals(next.Hash) && x.Block.Node == next.Node &&
-                                            x.Block.Round == next.Round));
+                        new ValueTask<bool>(x.Block.Hash.Equals(next.Hash) && x.Block.Round == GetRound() + 1));
                     if (blockGraph == null)
                     {
                         _logger.Here()


### PR DESCRIPTION
Return the last sampled value for a period of time so that when the subscription is fired. The query will use the back-end store instead of the events collection object as this will not return all items.

This will replace the last implementation as further testing is required within a complete system.